### PR TITLE
Look for types field in addition to typings

### DIFF
--- a/src/DocBuilder.ts
+++ b/src/DocBuilder.ts
@@ -44,7 +44,11 @@ export class DocBuilder {
 		var packagePath = path.resolve(basePath, 'package.json');
 		this.tsconfigPath = path.resolve(basePath, 'tsconfig.json');
 		var pkgJson = require(packagePath);
-		this.dtsPath = path.resolve(basePath, pkgJson.typings);
+		var typings = pkgJson.typings ? pkgJson.typings : pkgJson.types;
+		if (!typings) {
+			throw new Error('Expected either a "typings" or "types" field in package.json');
+		}
+		this.dtsPath = path.resolve(basePath, typings);
 
 		var gitUrl = pkgJson.repository && pkgJson.repository.url;
 


### PR DESCRIPTION
Typescript expects either a typings or a types field in package.json. This adds support for the `types` field to docts. Also throws an exception if neither are found.