### PR TITLE
Remove Backslashes in URL when generating on Windows

### DIFF
--- a/src/DocBuilder.ts
+++ b/src/DocBuilder.ts
@@ -102,7 +102,7 @@ export class DocBuilder {
 				this.gitRepo,
 				'blob',
 				source.shortHash || this.gitBranch,
-				path.relative(this.basePath, pos.sourcePath)
+				path.posix.relative(this.basePath, pos.sourcePath)
 			].join('/');
 
 			var urlHash = '#L' + pos.firstLine;

--- a/src/DocBuilder.ts
+++ b/src/DocBuilder.ts
@@ -102,7 +102,7 @@ export class DocBuilder {
 				this.gitRepo,
 				'blob',
 				source.shortHash || this.gitBranch,
-				path.posix.relative(this.basePath, pos.sourcePath)
+				path.relative(this.basePath, pos.sourcePath).replace(/\\/g, "/")
 			].join('/');
 
 			var urlHash = '#L' + pos.firstLine;


### PR DESCRIPTION
Using path.relative() on Windows results in backslashes appearing in the source code URLs.

path.posix.relative() would fix the issue but I believe that would require upgrading the @types/node dependency.